### PR TITLE
feat: deprecate support for Terraform 0.12 and 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,31 @@
 
 A Terraform Module to configure the S3 Data Export integration for Lacework.
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 0.3 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 0.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_lacework_s3_iam_role"></a> [lacework\_s3\_iam\_role](#module\_lacework\_s3\_iam\_role) | lacework/iam-role/aws | ~> 0.1 |
+
 ## Inputs
 
 | Name                        | Description                                                                                                          | Type          | Default                     | Required |

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 0.14"
 
   required_providers {
     aws    = "~> 4.0"


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Deprecate support for Terraform 0.12 and 0.13

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Add Terraform 1.1 to terraform modules compatibility tests

## Issue

https://lacework.atlassian.net/browse/ALLY-954

