### PR TITLE
fix: tfsec violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,25 +36,33 @@ A Terraform Module to configure the S3 Data Export integration for Lacework.
 
 | Name | Type |
 |------|------|
+| [aws_kms_key.lacework_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_iam_policy.cross_account_s3_write_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.cross_account_s3_write_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_bucket.s3_data_export_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.cloudtrail_log_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_public_access_block.s3_data_export_bucket_acess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.log_bucket_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_versioning.log_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.log_bucket_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption) | resource |
 | [aws_s3_bucket_versioning.export__versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [lacework_alert_channel_aws_s3.data_export](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/alert_channel_aws_s3) | resource |
 | [lacework_data_export_rule.example](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/data_export_rule) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [time_sleep.wait_time](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_iam_policy_document.cross_account_s3_write_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_access_log_prefix"></a> [access\_log\_prefix](#input\_access\_log\_prefix) | Optional value to specify a key prefix for access log objects for logging S3 bucket | `string` | `"log/"` | no |
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | The S3 bucket ARN is required when setting `use_existing_s3_bucket` to `true` | `string` | `""` | no |
-| <a name="input_bucket_enable_encryption"></a> [bucket\_enable\_encryption](#input\_bucket\_enable\_encryption) | Set this to `true` to enable encryption on a created S3 bucket | `bool` | `false` | no |
+| <a name="input_bucket_enable_encryption"></a> [bucket\_enable\_encryption](#input\_bucket\_enable\_encryption) | Set this to `true` to enable encryption on a created S3 bucket | `bool` | `true` | no |
 | <a name="input_bucket_enable_mfa_delete"></a> [bucket\_enable\_mfa\_delete](#input\_bucket\_enable\_mfa\_delete) | Set this to `true` to require MFA for object deletion (Requires versioning) | `bool` | `false` | no |
-| <a name="input_bucket_enable_versioning"></a> [bucket\_enable\_versioning](#input\_bucket\_enable\_versioning) | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | `false` | no |
+| <a name="input_bucket_enable_versioning"></a> [bucket\_enable\_versioning](#input\_bucket\_enable\_versioning) | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | `true` | no |
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket (Required when bucket not empty) | `bool` | `false` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The S3 bucket name is required when setting `use_existing_s3_bucket` to `true` | `string` | `""` | no |
 | <a name="input_bucket_sse_algorithm"></a> [bucket\_sse\_algorithm](#input\_bucket\_sse\_algorithm) | The encryption algorithm to use for S3 bucket server-side encryption | `string` | `"AES256"` | no |
@@ -73,6 +81,13 @@ A Terraform Module to configure the S3 Data Export integration for Lacework.
 | <a name="input_use_existing_iam_role"></a> [use\_existing\_iam\_role](#input\_use\_existing\_iam\_role) | Set this to `true` to use an existing IAM role | `bool` | `false` | no |
 | <a name="input_use_existing_s3_bucket"></a> [use\_existing\_s3\_bucket](#input\_use\_existing\_s3\_bucket) | Set this to `true` to use an existing S3 bucket | `bool` | `false` | no |
 | <a name="input_wait_time"></a> [wait\_time](#input\_wait\_time) | Amount of time to wait before the next resource is provisioned. | `string` | `"10s"` | no |
+| <a name="input_kms_key_rotation"></a> [kms\_key\_rotation](#kms\_key\_rotation) | Enable KMS automatic key rotation | `bool` | `true` | no |
+| <a name="input_kms_key_deletion_days"></a> [kms\_key\_deletion\_days](#kms\_key\_deletion\_days) | The waiting period, specified in number of days | `number` | `30` | no |
+| <a name="input_kms_key_multi_region"></a> [kms\_key\_multi\_region](#kms\_key\_multi\_region) | Whether the KMS key is a multi-region or regional key | `bool` | `true` | no |
+| <a name="input_use_existing_access_log_bucket"></a> [use\_existing\_access\_log\_bucket](#input\_use\_existing\_access\_log\_bucket) | Set this to `true` to use an existing bucket for access logging. Default behavior creates a new access log bucket if logging is enabled | `bool` | `false` | no |
+| <a name="input_log_bucket_name"></a> [log\_bucket\_name](#input\_log\_bucket\_name) | The S3 bucket name is required when setting `use_existing_access_log_bucket` to `true` | `string` | `""` | no |
+| <a name="input_bucket_logs_disabled"></a> [bucket\_logs\_disabled](#input\_bucket\_logs\_enabled) | Set this to `true` to disable access logging on a created S3 bucket | `bool` | `false` | no |
+
 
 ## Outputs
 

--- a/examples/encryption-algo/README.md
+++ b/examples/encryption-algo/README.md
@@ -1,0 +1,26 @@
+# S3 Data Export KMS Encryption Example
+
+This example creates a new S3 bucket as well as an IAM Role with a cross-account policy to provide Lacework write access to the bucket.
+
+By default the SSE algorithm is `aws:kms`, this example shows how `AES256` can be used instead.
+
+## Sample Code
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {}
+
+module "s3_data_export" {
+  source  = "lacework/s3-data-export/aws"
+  version = "~> 0.1"
+
+  bucket_sse_algorithm = "AES256"
+}
+```

--- a/examples/encryption-algo/main.tf
+++ b/examples/encryption-algo/main.tf
@@ -1,0 +1,7 @@
+provider "lacework" {}
+
+module "lacework_s3_data_export" {
+  source = "../.."
+
+  bucket_sse_algorithm = "AES256"
+}

--- a/examples/encryption-algo/versions.tf
+++ b/examples/encryption-algo/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/examples/existing-log-bucket/README.md
+++ b/examples/existing-log-bucket/README.md
@@ -1,0 +1,38 @@
+# S3 Data Export w/ Existing Bucket
+
+This example uses an existing S3 bucket while creating an IAM Role with a cross-account policy to provide Lacework write access to the bucket.
+
+## Inputs
+
+| Name                           | Description                                                                            | Type     |
+| ------------------------------ | -------------------------------------------------------------------------------------- | -------- |
+| bucket_arn                     | The S3 bucket ARN is required when setting `use_existing_s3_bucket` to `true`          | `string` |
+| bucket_name                    | The S3 bucket name is required when setting `use_existing_s3_bucket` to `true`         | `string` |
+| log_bucket_name                | The S3 bucket name is required when setting `use_existing_access_log_bucket` to `true` | `string` |
+| use_existing_s3_bucket         | Set this to `true` to use an existing S3 bucket                                        | `bool`   |
+| use_existing_access_log_bucket | Set this to `true` to use an existing S3 bucket                                        | `bool`   |
+
+## Sample Code
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "lacework" {}
+
+module "lacework_module" {
+  source  = "lacework/s3-data-export/aws"
+  version = "~> 0.1"
+
+  use_existing_s3_bucket         = true
+  use_existing_access_log_bucket = true
+  bucket_arn                     = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
+  bucket_name                    = "lacework-ct-bucket-8805c0bf"
+  log_bucket_name                = "lacework-ct-bucket-8805c0bf-access-logs"
+}
+```

--- a/examples/existing-log-bucket/main.tf
+++ b/examples/existing-log-bucket/main.tf
@@ -1,0 +1,11 @@
+provider "lacework" {}
+
+module "lacework_s3_data_export" {
+  source = "../.."
+
+  use_existing_s3_bucket         = true
+  use_existing_access_log_bucket = true
+  bucket_arn                     = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
+  bucket_name                    = "lacework-ct-bucket-8805c0bf"
+  log_bucket_name                = "lacework-ct-bucket-8805c0bf-access-logs"
+}

--- a/examples/existing-log-bucket/versions.tf
+++ b/examples/existing-log-bucket/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
-  bucket_name = length(var.bucket_name) > 0 ? var.bucket_name : "${var.prefix}-bucket-${random_id.uniq.hex}"
-  bucket_arn  = var.use_existing_s3_bucket ? trimsuffix(var.bucket_arn, "/") : aws_s3_bucket.s3_data_export_bucket[0].arn
+  bucket_name     = length(var.bucket_name) > 0 ? var.bucket_name : "${var.prefix}-bucket-${random_id.uniq.hex}"
+  log_bucket_name = length(var.log_bucket_name) > 0 ? var.log_bucket_name : "${local.bucket_name}-access-logs"
+  bucket_arn      = var.use_existing_s3_bucket ? trimsuffix(var.bucket_arn, "/") : aws_s3_bucket.s3_data_export_bucket[0].arn
   cross_account_policy_name = (
     length(var.cross_account_policy_name) > 0 ? var.cross_account_policy_name : "${var.prefix}-cross-acct-policy-${random_id.uniq.hex}"
   )
@@ -11,10 +12,22 @@ locals {
   )
   mfa_delete               = var.bucket_enable_versioning && var.bucket_enable_mfa_delete ? "Enabled" : "Disabled"
   bucket_enable_versioning = var.bucket_enable_versioning ? "Enabled" : "Suspended"
+  create_kms_key           = var.bucket_enable_encryption && length(var.bucket_sse_key_arn) == 0 && var.bucket_sse_algorithm == "aws:kms" ? 1 : 0
+  bucket_sse_key_arn       = var.bucket_enable_encryption ? (length(var.bucket_sse_key_arn) > 0 ? var.bucket_sse_key_arn : (local.create_kms_key == 1 ? aws_kms_key.lacework_kms_key[0].arn: "")) : ""
 }
 
 resource "random_id" "uniq" {
   byte_length = 4
+}
+
+resource "aws_kms_key" "lacework_kms_key" {
+  count                   = local.create_kms_key
+  description             = "A KMS key used to encrypt S3 bucket data"
+  deletion_window_in_days = var.kms_key_deletion_days
+  multi_region            = var.kms_key_multi_region
+  tags                    = var.tags
+  policy                  = data.aws_iam_policy_document.kms_key_policy[0].json
+  enable_key_rotation     = var.kms_key_rotation
 }
 
 module "lacework_s3_iam_role" {
@@ -48,6 +61,7 @@ data "aws_iam_policy_document" "cross_account_s3_write_access" {
     actions   = ["s3:ListBucket"]
   }
 
+  #tfsec:ignore:aws-iam-no-policy-wildcards
   statement {
     sid       = "PutObjectsInBucket"
     actions   = ["s3:GetObject", "s3:PutObject"]
@@ -59,17 +73,96 @@ data "aws_iam_policy_document" "cross_account_s3_write_access" {
     content {
       sid       = "EncryptFiles"
       actions   = ["kms:Encrypt", "kms:Decrypt"]
-      resources = [var.bucket_sse_key_arn]
+      resources = [local.bucket_sse_key_arn]
     }
   }
 }
 
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "kms_key_policy" {
+    version = "2012-10-17"
+
+    count = local.create_kms_key
+
+    statement {
+      sid    = "Enable account root to use/manage KMS key"
+      effect = "Allow"
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      }
+      actions   = ["kms:*"]
+      resources = ["*"]
+    }
+
+    statement {
+      sid    = "Allow S3 service to use KMS key when S3 is encrypted"
+      effect = "Allow"
+      principals {
+        type        = "Service"
+        identifiers = ["s3.amazonaws.com"]
+      }
+      actions = [
+        "kms:GenerateDataKey*",
+        "kms:Decrypt"
+      ]
+      resources = ["*"]
+    }
+
+    statement {
+      sid    = "Allow Lacework to use KMS Key"
+      effect = "Allow"
+      principals {
+        identifiers = ["arn:aws:iam::${var.lacework_aws_account_id}:root"]
+        type        = "AWS"
+      }
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ]
+      resources = ["*"]
+    }
+
+    statement {
+      sid    = "Allow principals in the account to decrypt with KMS key"
+      effect = "Allow"
+      principals {
+        type        = "AWS"
+        identifiers = ["*"]
+      }
+      actions = [
+        "kms:Decrypt",
+        "kms:ReEncryptFrom"
+      ]
+      resources = ["*"]
+      condition {
+        test     = "StringEquals"
+        variable = "kms:CallerAccount"
+        values   = [data.aws_caller_identity.current.account_id]
+      }
+    }
+}
+
+#tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "s3_data_export_bucket" {
   count         = var.use_existing_s3_bucket ? 0 : 1
   bucket        = local.bucket_name
   force_destroy = var.bucket_force_destroy
   tags          = var.tags
 }
+
+  resource "aws_s3_bucket_public_access_block" "s3_data_export_bucket_access" {
+    count                   = var.use_existing_s3_bucket ? 0 : 1
+    bucket                  = aws_s3_bucket.s3_data_export_bucket[0].id
+    block_public_acls       = true
+    block_public_policy     = true
+    ignore_public_acls      = true
+    restrict_public_buckets = true
+  }
 
 // v4 s3 bucket changes
 resource "aws_s3_bucket_versioning" "export__versioning" {
@@ -86,7 +179,51 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail_log_en
   bucket = aws_s3_bucket.s3_data_export_bucket[0].id
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = var.bucket_sse_key_arn
+      kms_master_key_id = local.bucket_sse_key_arn
+      sse_algorithm     = var.bucket_sse_algorithm
+    }
+  }
+}
+
+resource "aws_s3_bucket_logging" "s3_data_export_bucket_logging" {
+  count         = var.bucket_logs_disabled ? 0 : (var.use_existing_s3_bucket ? 0 : 1)
+  bucket        = aws_s3_bucket.s3_data_export_bucket[0].id
+  target_bucket = var.use_existing_access_log_bucket ? local.log_bucket_name : aws_s3_bucket.log_bucket[0].id
+  target_prefix = var.access_log_prefix
+}
+
+#tfsec:ignore:aws-s3-enable-bucket-logging
+resource "aws_s3_bucket" "log_bucket" {
+  count         = var.use_existing_access_log_bucket ? 0 : (var.bucket_logs_disabled ? 0 : 1)
+  bucket        = local.log_bucket_name
+  force_destroy = var.bucket_force_destroy
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "log_bucket_access" {
+  count                   = var.use_existing_access_log_bucket ? 0 : (var.bucket_logs_disabled ? 0 : 1)
+  bucket                  = aws_s3_bucket.log_bucket[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "log_bucket_versioning" {
+  count  = var.use_existing_access_log_bucket ? 0 : (var.bucket_logs_disabled ? 0 : 1)
+  bucket = aws_s3_bucket.log_bucket[0].id
+  versioning_configuration {
+    status     = local.bucket_enable_versioning
+    mfa_delete = local.mfa_delete
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket_encryption" {
+  count  = var.use_existing_access_log_bucket ? 0 : (var.bucket_logs_disabled ? 0 : var.bucket_enable_encryption? 1: 0)
+  bucket = aws_s3_bucket.log_bucket[0].id
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = local.bucket_sse_key_arn
       sse_algorithm     = var.bucket_sse_algorithm
     }
   }

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -11,6 +11,7 @@ readonly project_name=terraform-aws-s3-data-export
 TEST_CASES=(
   examples/default
   examples/existing-bucket
+  examples/existing-log-bucket
   examples/existing-iam-role
 )
 
@@ -38,9 +39,15 @@ lint_tests() {
   terraform fmt -check
 }
 
+sec_tests() {
+  # TODO: replace with `lacework iac tf-scan tfsec -m MEDIUM`
+  tfsec -m MEDIUM
+}
+
 main() {
   lint_tests
   integration_tests
+  sec_tests
 }
 
 main || exit 99

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "access_log_prefix" {
+  type        = string
+  default     = "log/"
+  description = "Optional value to specify a key prefix for access log objects for logging S3 bucket"
+}
+
 variable "bucket_name" {
   type        = string
   default     = ""
@@ -12,7 +18,7 @@ variable "bucket_arn" {
 
 variable "bucket_enable_encryption" {
   type        = bool
-  default     = false
+  default     = true
   description = "Set this to `true` to enable encryption on a created S3 bucket"
 }
 
@@ -24,7 +30,7 @@ variable "bucket_enable_mfa_delete" {
 
 variable "bucket_enable_versioning" {
   type        = bool
-  default     = false
+  default     = true
   description = "Set this to `true` to enable access versioning on a created S3 bucket"
 }
 
@@ -34,9 +40,15 @@ variable "bucket_force_destroy" {
   description = "Force destroy bucket (Required when bucket not empty)"
 }
 
+variable "bucket_logs_disabled" {
+  type        = bool
+  default     = false
+  description = "Set this to `true` to disable access logging on a created S3 bucket"
+}
+
 variable "bucket_sse_algorithm" {
   type        = string
-  default     = "AES256"
+  default     = "aws:kms"
   description = "The encryption algorithm to use for S3 bucket server-side encryption"
 }
 
@@ -75,6 +87,24 @@ variable "iam_role_external_id" {
   description = "The external ID configured inside the IAM role is required when setting `use_existing_iam_role` to `true`"
 }
 
+variable "kms_key_deletion_days" {
+  type        = number
+  default     = 30
+  description = "The waiting period, specified in number of days"
+}
+
+variable "kms_key_multi_region" {
+  type        = bool
+  default     = true
+  description = "Whether the KMS key is a multi-region or regional key"
+}
+
+variable "kms_key_rotation" {
+  type        = bool
+  default     = true
+  description = "Enable KMS automatic key rotation"
+}
+
 variable "lacework_alert_channel_name" {
   type        = string
   default     = "TF S3 Data Export"
@@ -99,6 +129,12 @@ variable "lacework_aws_account_id" {
   description = "The Lacework AWS account that the IAM role will grant access"
 }
 
+variable "log_bucket_name" {
+  type        = string
+  default     = ""
+  description = "Name of the S3 bucket for access logs. Is required when setting `use_existing_access_log_bucket` to true"
+}
+
 variable "prefix" {
   type        = string
   default     = "lacework-s3-data-export"
@@ -109,6 +145,12 @@ variable "tags" {
   type        = map(string)
   description = "A map/dictionary of Tags to be assigned to created resources"
   default     = {}
+}
+
+variable "use_existing_access_log_bucket" {
+  type        = bool
+  default     = false
+  description = "Set this to `true` to use an existing bucket for access logging. Default behavior creates a new access log bucket if logging is enabled"
 }
 
 variable "use_existing_s3_bucket" {


### PR DESCRIPTION
## Summary

Addressing violations raised by tfsec.

Default S3 bucket SSE algorithm is now `aws:kms`.

This PR ignores the following violations:
* policy S3 resource wildcard - required to use objects in the bucket
* S3 bucket logging - logging added but tfsec only recognised the deprecated nested configuration

## How did you test this change?

- creation
- upgrade
- downgrade
- switching encryption algorithm

## Issue

https://lacework.atlassian.net/browse/GROW-1460
