### PR TITLE
chore: enable bucket_force_destroy by default

### DIFF
--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -94,7 +94,6 @@ module "aws_cloudtrail" {
   source  = "lacework/cloudtrail/aws"
   version = "~> 0.1"
 
-  bucket_force_destroy  = true
   use_existing_iam_role = true
   iam_role_name         = module.aws_config.iam_role_name
   iam_role_arn          = module.aws_config.iam_role_arn

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A Terraform Module to configure the S3 Data Export integration for Lacework.
 | <a name="input_bucket_enable_encryption"></a> [bucket\_enable\_encryption](#input\_bucket\_enable\_encryption) | Set this to `true` to enable encryption on a created S3 bucket | `bool` | `true` | no |
 | <a name="input_bucket_enable_mfa_delete"></a> [bucket\_enable\_mfa\_delete](#input\_bucket\_enable\_mfa\_delete) | Set this to `true` to require MFA for object deletion (Requires versioning) | `bool` | `false` | no |
 | <a name="input_bucket_enable_versioning"></a> [bucket\_enable\_versioning](#input\_bucket\_enable\_versioning) | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | `true` | no |
-| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket (Required when bucket not empty) | `bool` | `false` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket) | `bool` | `true` | no |
 | <a name="input_bucket_logs_disabled"></a> [bucket\_logs\_disabled](#input\_bucket\_logs\_disabled) | Set this to `true` to disable access logging on a created S3 bucket | `bool` | `false` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The S3 bucket name is required when setting `use_existing_s3_bucket` to `true` | `string` | `""` | no |
 | <a name="input_bucket_sse_algorithm"></a> [bucket\_sse\_algorithm](#input\_bucket\_sse\_algorithm) | The encryption algorithm to use for S3 bucket server-side encryption | `string` | `"aws:kms"` | no |

--- a/examples/data_export_rule/README.md
+++ b/examples/data_export_rule/README.md
@@ -18,7 +18,9 @@ terraform {
 provider "lacework" {}
 
 module "s3_data_export" {
-  source                                = "lacework/s3-data-export/aws"
+  source  = "lacework/s3-data-export/aws"
+  version = "~> 1.0"
+
   lacework_data_export_rule_name        = "Lacework Data Export Rule Name"
   lacework_data_export_rule_description = "Lacework Data Export Rule Description"
 }

--- a/examples/data_export_rule/main.tf
+++ b/examples/data_export_rule/main.tf
@@ -1,7 +1,8 @@
 provider "lacework" {}
 
 module "lacework_s3_data_export" {
-  source                                = "../.."
+  source = "../.."
+
   lacework_data_export_rule_name        = "Lacework Data Export Rule Name"
   lacework_data_export_rule_description = "Lacework Data Export Rule Description"
 }

--- a/main.tf
+++ b/main.tf
@@ -3,17 +3,17 @@ locals {
   log_bucket_name = length(var.log_bucket_name) > 0 ? var.log_bucket_name : "${local.bucket_name}-access-logs"
   bucket_arn      = var.use_existing_s3_bucket ? trimsuffix(var.bucket_arn, "/") : aws_s3_bucket.s3_data_export_bucket[0].arn
   cross_account_policy_name = (
-  length(var.cross_account_policy_name) > 0 ? var.cross_account_policy_name : "${var.prefix}-cross-acct-policy-${random_id.uniq.hex}"
+    length(var.cross_account_policy_name) > 0 ? var.cross_account_policy_name : "${var.prefix}-cross-acct-policy-${random_id.uniq.hex}"
   )
   iam_role_arn         = module.lacework_s3_iam_role.created ? module.lacework_s3_iam_role.arn : var.iam_role_arn
   iam_role_external_id = module.lacework_s3_iam_role.created ? module.lacework_s3_iam_role.external_id : var.iam_role_external_id
   iam_role_name = var.use_existing_iam_role ? var.iam_role_name : (
-  length(var.iam_role_name) > 0 ? var.iam_role_name : "${var.prefix}-iam-${random_id.uniq.hex}"
+    length(var.iam_role_name) > 0 ? var.iam_role_name : "${var.prefix}-iam-${random_id.uniq.hex}"
   )
   mfa_delete               = var.bucket_enable_versioning && var.bucket_enable_mfa_delete ? "Enabled" : "Disabled"
   bucket_enable_versioning = var.bucket_enable_versioning ? "Enabled" : "Suspended"
   create_kms_key           = var.bucket_enable_encryption && length(var.bucket_sse_key_arn) == 0 && var.bucket_sse_algorithm == "aws:kms" ? 1 : 0
-  bucket_sse_key_arn       = var.bucket_enable_encryption ? (length(var.bucket_sse_key_arn) > 0 ? var.bucket_sse_key_arn : (local.create_kms_key == 1 ? aws_kms_key.lacework_kms_key[0].arn: "")) : ""
+  bucket_sse_key_arn       = var.bucket_enable_encryption ? (length(var.bucket_sse_key_arn) > 0 ? var.bucket_sse_key_arn : (local.create_kms_key == 1 ? aws_kms_key.lacework_kms_key[0].arn : "")) : ""
 }
 
 resource "random_id" "uniq" {
@@ -237,7 +237,7 @@ resource "aws_s3_bucket_versioning" "log_bucket_versioning" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "log_bucket_encryption" {
-  count  = var.use_existing_access_log_bucket ? 0 : (var.bucket_logs_disabled ? 0 : var.bucket_enable_encryption? 1: 0)
+  count  = var.use_existing_access_log_bucket ? 0 : (var.bucket_logs_disabled ? 0 : var.bucket_enable_encryption ? 1 : 0)
   bucket = aws_s3_bucket.log_bucket[0].id
   rule {
     apply_server_side_encryption_by_default {

--- a/variables.tf
+++ b/variables.tf
@@ -36,8 +36,8 @@ variable "bucket_enable_versioning" {
 
 variable "bucket_force_destroy" {
   type        = bool
-  default     = false
-  description = "Force destroy bucket (Required when bucket not empty)"
+  default     = true
+  description = "Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket)"
 }
 
 variable "bucket_logs_disabled" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

When we use this module to automatically deploy and rollback changes. Users are having
constant issues trying to destroy the S3 bucket if it is not empty. To unblock this problem,
users need to turn on the `bucket_force_destroy` flag, and then do any modification that
requires a "destroy" operation.

By default, we should allow users to do these operations without the need to know about
this flag, if users does not wish to allow these buckets to be destroyed when they are not
empty, users should switch off the flag with `bucket_force_destroy = false`.

## How did you test this change?

After merge, we will run our internal pipeline https://github.com/lacework/terraform-customerdemo/pull/70

## Issue
https://lacework.atlassian.net/browse/GROW-1336
